### PR TITLE
fix: add 'attrs' to 'install_requires'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
+        'attrs',
         'libghdl==0.37.dev0'
     ],
 


### PR DESCRIPTION
Package 'attrs' is a dependency of ghdl-ls. This PR ensures that it is installed automatically.