### PR TITLE
remove 'vscode' from devDependencies

### DIFF
--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -70,11 +70,11 @@
 				}
 			]
 		},
-        "configurationDefaults": {
-            "[vhdl]": {
-                "files.encoding": "iso88591"
-            }
-        },
+		"configurationDefaults": {
+			"[vhdl]": {
+				"files.encoding": "iso88591"
+			}
+		},
 		"configuration": {
 			"type": "object",
 			"title": "Vhdl configuration",
@@ -111,8 +111,7 @@
 		"@types/node": "^8.10.25",
 		"@types/vscode": "^1.34.0",
 		"tslint": "^5.16.0",
-		"typescript": "^3.5.1",
-		"vscode": "^1.1.34"
+		"typescript": "^3.5.1"
 	},
 	"dependencies": {
 		"vscode-languageclient": "^4.1.4"


### PR DESCRIPTION
Building the VSC LSP client extension is failing: https://travis-ci.com/ghdl/docker/builds/121832093 I think it is because `vscode` is still declared as a `devDependency`, even thought it has been split: https://www.npmjs.com/package/vscode

According to migration instructions (https://code.visualstudio.com/api/working-with-extensions/testing-extension#migrating-from-vscode), besides removing `vscode`, `vscode-test` should be added. However, since this repo does not have any JS/TS test, I believe it is not required.