### PR TITLE
vscode-client: add '-dev' suffix to version

### DIFF
--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -3,7 +3,7 @@
 	"description": "VHDL language server",
 	"author": "Tristan Gingold",
 	"license": "GPL-2.0-or-later",
-	"version": "0.1.0",
+	"version": "0.1.0-dev",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/ghdl/ghdl-language-server"


### PR DESCRIPTION
Add suffix to version semver, in order to make it explicit that building from sources is a development task.