### PR TITLE
Add few words about hdl-prj.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,29 @@ export PYTHONPATH=$PYTHONPATH:$(pwd)
 The executable is named `ghdl-ls`. It uses stdin/stdout to communicate with
 its client.
 
+The language server will require a project file named `hdl-prj.json` which will provide all required options to run GHDL analysis :
+ - All options to pass to `ghdl -a`
+ - Your project fileset
+
+An example of `hdl-prj.json` file could be :
+```json
+{
+    "options": {
+        "ghdl_analysis": [
+            "--workdir=work",
+            "--ieee=synopsys",
+            "-fexplicit"
+        ]
+    },
+    "files": [
+        { "file": "rtl/core.vhd",           "language": "vhdl" },
+        { "file": "assembly/core_fpga.vhd", "language": "vhdl" },
+        { "file": "sim/tb_core.vhd", 		"language": "vhdl" }
+    ]
+}
+```
+ 
+
 # Visual Studio Code (VSC) Extension
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The executable is named `ghdl-ls`. It uses stdin/stdout to communicate with
 its client.
 
 The language server will require a project file named `hdl-prj.json` which will provide all required options to run GHDL analysis :
- - All options to pass to `ghdl -a`
+ - All options to pass to `ghdl -a` (the analysis step)
  - Your project fileset
 
 An example of `hdl-prj.json` file could be :
@@ -67,7 +67,8 @@ An example of `hdl-prj.json` file could be :
     ]
 }
 ```
- 
+
+You will find all valid options in the GHDL documentation in the [options to invoke GHDL](https://ghdl.readthedocs.io/en/latest/using/InvokingGHDL.html#options).
 
 # Visual Studio Code (VSC) Extension
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ An example of `hdl-prj.json` file could be :
     "files": [
         { "file": "rtl/core.vhd",           "language": "vhdl" },
         { "file": "assembly/core_fpga.vhd", "language": "vhdl" },
-        { "file": "sim/tb_core.vhd", 		"language": "vhdl" }
+        { "file": "sim/tb_core.vhd",        "language": "vhdl" }
     ]
 }
 ```


### PR DESCRIPTION
Hi !
As discussed in #12 here is a few words added to the readme, in order to mention `hdl-prj.json`.

It may be required to edit the actual ghdl command (here `ghdl -a`) and I'm not sure about the hdl-prj.json being used by emacs.

If there is any editions to be made, please let me know.
Best regards,
Julien
