### PR TITLE
Add component template

### DIFF
--- a/vscode-client/snippets.vhdl.json
+++ b/vscode-client/snippets.vhdl.json
@@ -65,10 +65,10 @@
 		"body": [
 		"component ${1:entity} is",
 		"	generic(",
-		"		${3:generics}",
+		"		${2:generics}",
 		"	);",
 		"	port(",
-		"		${2:ports}",
+		"		${3:ports}",
 		"	);",
 		"end component;"
 		],

--- a/vscode-client/snippets.vhdl.json
+++ b/vscode-client/snippets.vhdl.json
@@ -59,5 +59,20 @@
 			"end ${1};"
 		],
 		"description": "package body"
+	},
+	"Component": {
+		"prefix":"component",
+		"body": [
+		"component ${1:entity} is",
+		"	generic(",
+		"		${3:generics}",
+		"	);",
+		"	port(",
+		"		${2:ports}",
+		"	);",
+		"end component;"
+		],
+		"description": "component declaration"
 	}
 }
+


### PR DESCRIPTION
This PR add the following VHDL snippet :

```vhdl
    component entity is
        generic(
            generics
        );
        port(
            ports
        );
    end component;
```

Where `entity`, `generics` and `ports` are default values.
If the presentation of the snippet doesn't fulfill some presentation rules, please let me know.