### PR TITLE
bump VSC extension dependencies

### DIFF
--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -124,18 +124,18 @@
 		"tsc-watch": "tsc -b -w"
 	},
 	"engines": {
-		"vscode": "^1.34.0"
+		"vscode": "^1.41.0"
 	},
 	"devDependencies": {
-		"@types/node": "^12.6.9",
-		"@types/vscode": "^1.34.0",
-		"ts-loader": "^6.0.4",
-		"tslint": "^5.16.0",
-		"typescript": "^3.5.1",
-		"webpack": "^4.39.1",
-		"webpack-cli": "^3.3.6"
+		"@types/node": "^13.5.0",
+		"@types/vscode": "^1.41.0",
+		"ts-loader": "^6.2.1",
+		"tslint": "^6.0.0",
+		"typescript": "^3.7.5",
+		"webpack": "^4.41.5",
+		"webpack-cli": "^3.3.10"
 	},
 	"dependencies": {
-		"vscode-languageclient": "^5.2.1"
+		"vscode-languageclient": "^6.0.1"
 	}
 }


### PR DESCRIPTION
VSC extension dependencies are outdated. This PR bumps them.