### PR TITLE
Update emacs configuration

### DIFF
--- a/emacs-client/README.org
+++ b/emacs-client/README.org
@@ -194,14 +194,10 @@ Setup related to the language server protocol.
   (use-package vhdl-mode
     :defer t
     :config
-    (require 'lsp)
-    (lsp-register-client
-     (make-lsp-client :new-connection (lsp-stdio-connection '("ghdl-ls" "-v" "--trace-file=/tmp/emacs.d/vhdl-ls.trace"))
-                      :major-modes '(vhdl-mode)
-                      :priority -1
-                      :server-id 'lsp-vhdl-mode))
+    (require 'lsp-vhdl)
+    (setq lsp-vhdl-server 'ghdl-ls
+          lsp-vhdl--params nil)
     :hook (vhdl-mode . (lambda()
-                         (lsp)
-                         (flycheck-mode t)
-                         (add-to-list 'lsp-language-id-configuration '(vhdl-mode . "vhdl")))))
+                         (lsp t)
+                         (flycheck-mode t))))
 #+end_src


### PR DESCRIPTION
As for [this](https://github.com/emacs-lsp/lsp-mode/pull/1367), lsp for emacs now includes native calling support for ghdl-ls, so configuration gets simplified.