### PR TITLE
fix libghdl version

### DIFF
--- a/ghdl-ls/setup.py
+++ b/ghdl-ls/setup.py
@@ -32,7 +32,7 @@ setup(
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
         'attrs',
-        'libghdl==0.37.dev0'
+        'libghdl==0.1.dev0'
     ],
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and allow


### PR DESCRIPTION
After releasing `v0.37`, the new development version is `0.1.dev0`.

https://github.com/ghdl/docker/runs/476046544?check_suite_focus=true