### PR TITLE
Increase log verbosity for debug mode for vscode.

### DIFF
--- a/vscode-client/extension.ts
+++ b/vscode-client/extension.ts
@@ -89,7 +89,7 @@ export function activate(context: vscode.ExtensionContext) {
 		},
 		debug: {
 			command: serverPath,
-			args: ['-v', '--trace-file=vhdl-ls.trace']
+			args: ['-vvv', '--trace-file=vhdl-ls.trace']
 		}
 	};
 

--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -104,7 +104,7 @@
 					"scope": "window",
 					"type": "boolean",
 					"default": false,
-					"description": "Traces the communication between VS Code and the language server."
+					"description": "Increase log verbosity and trace the communication between VS Code and the language server."
 				}
 			}
 		}


### PR DESCRIPTION
Probably it would be better to have separate setting for verbosity level. However, it is beyond my knowledge on typescript and vscode extension infrastructure.