### PR TITLE
vscode-client: bump dependencies

### DIFF
--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -118,18 +118,18 @@
 		"tsc-watch": "tsc -b -w"
 	},
 	"engines": {
-		"vscode": "^1.45.1"
+		"vscode": "^1.52.0"
 	},
 	"devDependencies": {
-		"@types/node": "^14.0.4",
-		"@types/vscode": "^1.45.1",
-		"ts-loader": "^8.0.0",
-		"tslint": "^6.1.2",
-		"typescript": "^4.0.2",
-		"webpack": "^5.1.3",
-		"webpack-cli": "^4.0.0"
+		"@types/node": "^14.14.14",
+		"@types/vscode": "^1.52.0",
+		"ts-loader": "^8.0.12",
+		"tslint": "^6.1.3",
+		"typescript": "^4.1.3",
+		"webpack": "^5.10.3",
+		"webpack-cli": "^4.2.0"
 	},
 	"dependencies": {
-		"vscode-languageclient": "^6.1.3"
+		"vscode-languageclient": "^7.0.0"
 	}
 }


### PR DESCRIPTION
CI is failing, but it was not shown because this repo did not have any push/PR in some weeks. I added a cron event to the workflow. Pushing it triggered a run, where the problem is seen:

- https://github.com/ghdl/ghdl-language-server/runs/1569702175?check_suite_focus=true
- https://github.com/ghdl/ghdl-language-server/runs/1569702175?check_suite_focus=true#step:3:46

It seems that something changed in VSCode's API.

In this PR, the dependencies are updated. But it does not solve the problem. It seems that something needs to be updated in the vscode extension.

Ref #69